### PR TITLE
Fix build issues when running Docker Compose on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.sh text eol=lf
+*.bash text eol=lf
+Dockerfile text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/docker-compose-ollama.yml
+++ b/docker-compose-ollama.yml
@@ -8,7 +8,8 @@ services:
       - .:/src/
     command:
       - /bin/bash
-      - /src/scripts/build.sh
+      - -lc
+      - "tr -d '\r' < /src/scripts/build.sh > /tmp/build.sh && chmod +x /tmp/build.sh && /tmp/build.sh"
 
   import:
     image: neo4j:4.4-enterprise
@@ -22,7 +23,8 @@ services:
       - ./scripts/import.sh:/scripts/import.sh
     command:
       - /bin/bash
-      - /scripts/import.sh
+      - -lc
+      - "tr -d '\r' < /scripts/import.sh > /tmp/import.sh && chmod +x /tmp/import.sh && /tmp/import.sh"
     depends_on:
       build:
         condition: service_completed_successfully

--- a/docker-compose-ollama.yml
+++ b/docker-compose-ollama.yml
@@ -8,8 +8,7 @@ services:
       - .:/src/
     command:
       - /bin/bash
-      - -lc
-      - "tr -d '\r' < /src/scripts/build.sh > /tmp/build.sh && chmod +x /tmp/build.sh && /tmp/build.sh"
+      - /src/scripts/build.sh
 
   import:
     image: neo4j:4.4-enterprise
@@ -23,8 +22,7 @@ services:
       - ./scripts/import.sh:/scripts/import.sh
     command:
       - /bin/bash
-      - -lc
-      - "tr -d '\r' < /scripts/import.sh > /tmp/import.sh && chmod +x /tmp/import.sh && /tmp/import.sh"
+      - /scripts/import.sh
     depends_on:
       build:
         condition: service_completed_successfully

--- a/docker-compose-ollama.yml
+++ b/docker-compose-ollama.yml
@@ -56,7 +56,7 @@ services:
       import:
         condition: service_completed_successfully
     environment:
-      - OLLAMA_MODEL=llama3.1
+      - OLLAMA_MODEL=qwen3
       - OLLAMA_URL=http://host.docker.internal:11434
       - DOCKER_COMPOSE=true
       - CHAT_TAB=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
 
 volumes:
   biocypher_neo4j_volume:
+  
 
 
 networks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pole"
-version = "0.1.0"
+version = "0.2.0"
 description = "Knowledge Graph of Crime Demo dataset"
 authors = [
     "Sebastian Lobentanzer <sebastian.lobentanzer@gmail.com>",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -c
+#!/bin/bash
 cd /usr/app/
 cp -r /src/* .
 cp config/biocypher_docker_config.yaml config/biocypher_config.yaml

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -c
+#!/bin/bash
 sleep 2
 ls /data/build2neo/neo4j-admin-import-call.sh
 if [ -f /data/build2neo/neo4j-admin-import-call.sh ]; then


### PR DESCRIPTION
This pull request introduces several improvements to Docker and script configuration, primarily focusing on standardizing line endings, updating environment variables, and fixing script shebangs. These changes enhance cross-platform compatibility and ensure proper execution of shell scripts.

**Configuration standardization:**

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R5): Added rules to enforce LF line endings for shell scripts, Dockerfiles, and YAML files, improving consistency across environments.

**Environment updates:**

* [`docker-compose-ollama.yml`](diffhunk://#diff-293a080e92ef4bee6cb38e91de22bfd8117b15034680f7c0e603b51ceae84d93L59-R59): Changed the `OLLAMA_MODEL` environment variable from `llama3.1` to `qwen3`, updating the default model used by the service.

**Script execution fixes:**

* [`scripts/build.sh`](diffhunk://#diff-3d64996115d0ac3b74e36f57ce6b00d6b4982614c41b1ed39eab8ef43b2e9a2bL1-R1): Updated the shebang from `#!/bin/bash -c` to `#!/bin/bash` to ensure correct script execution.
* [`scripts/import.sh`](diffhunk://#diff-3b1a310795b6c660335aa35b9750b26b3776f1facd316d707ba616081a4330a1L1-R1): Updated the shebang from `#!/bin/bash -c` to `#!/bin/bash` for proper script execution.

**Docker Compose adjustments:**

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R71): Added a blank line before the `networks` section, likely for formatting or clarity.